### PR TITLE
Capitalize the B in 'based'

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
 # Example Repository
-**based on the lesson on [HouseLearning](https://houselearning.github.io/home/computer-science-page/github/)**
+**Based on the lesson on [HouseLearning](https://houselearning.github.io/home/computer-science-page/github/)**


### PR DESCRIPTION
Previously, I noticed that the 'B' in the word 'based' was not capitalized. So I decided to capitalize it for better readability.